### PR TITLE
fix: FLAMO/.json roundtrip fidelity for Gain, Matrix, and SOS.

### DIFF
--- a/src/flamo_rt/__init__.py
+++ b/src/flamo_rt/__init__.py
@@ -7,4 +7,9 @@ from flamo_rt.codegen.flamo_to_json import flamo_to_json
 from flamo_rt.codegen.json_to_faust import json_to_faust
 from flamo_rt.codegen.flamo_to_faust import flamo_to_faust
 
-__all__ = ["flamo_to_json", "json_to_faust", "flamo_to_faust"]
+try:
+    from flamo_rt.codegen.json_to_flamo import json_to_flamo
+except ImportError:
+    pass
+
+__all__ = ["flamo_to_json", "json_to_faust", "flamo_to_faust", "json_to_flamo"]

--- a/src/flamo_rt/codegen/flamo_to_json.py
+++ b/src/flamo_rt/codegen/flamo_to_json.py
@@ -252,26 +252,6 @@ def _normalise_sos(sos: np.ndarray) -> list:
     return normalised
 
 
-#gain shape classification
-
-def _classify_gain(param: np.ndarray) -> str:
-    """determine whether a gain parameter represents a matrix or diagonal gains.
-
-    returns "matrix" for any 2d param that mixes or routes channels
-    (including row vectors N to 1 and column vectors 1 to N).
-    returns "diagonal" for 1d params and scalar (1,1) gains.
-    """
-    if param.ndim == 1:
-        return "diagonal"
-    if param.ndim == 2:
-        n_out, n_in = param.shape
-        if n_out == 1 and n_in == 1:
-            #scalar gain, no routing needed
-            return "diagonal"
-        return "matrix"
-    return "matrix"
-
-
 #leaf node serialisation
 
 def _serialise_leaf(module: Any, name: str, fs: float) -> dict[str, Any]:
@@ -309,20 +289,32 @@ def _serialise_leaf(module: Any, name: str, fs: float) -> dict[str, Any]:
             "samples_fractional": _fractional_delays(param, fs),
         }
 
-    elif module_type in ("Gain", "Matrix", "HouseholderMatrix"):
-        shape_class = _classify_gain(param)
-        if shape_class == "matrix":
-            node["params"] = {
-                "matrix": param.tolist(),
-            }
-        else:
-            node["params"] = {
-                "gains": param.ravel().tolist(),
-            }
-
-    elif module_type == "parallelGain":
+    elif module_type in ("Gain", "parallelGain"):
+        #store the raw parameter at its original dimensionality.
+        #Gain is 2D (n_out, n_in); parallelGain is 1D (n_ch).
         node["params"] = {
-            "gains": param.ravel().tolist(),
+            "gain": param.tolist(),
+        }
+
+    elif module_type == "Matrix":
+        #Matrix applies a map() during forward that depends on
+        #matrix_type. for "random" the map is identity, so the raw
+        #param is the literal matrix. for "orthogonal" the map is
+        #matrix_exp(skew_matrix(x)), so the raw param is the skew
+        #generator, not the orthogonal matrix itself; store it under
+        #"skew" to flag that the map must be reapplied on reconstruction.
+        matrix_type = getattr(module, "matrix_type", "random")
+        key = "skew" if matrix_type == "orthogonal" else "matrix"
+        node["params"] = {
+            key: param.tolist(),
+        }
+
+    elif module_type == "HouseholderMatrix":
+        #raw (N, 1) reflection vector; HouseholderMatrix's map()
+        #normalises it to unit norm on reconstruction. stored under
+        #"matrix" to match what _build_householder expects.
+        node["params"] = {
+            "matrix": param.tolist(),
         }
 
     elif module_type == "parallelSOSFilter":

--- a/src/flamo_rt/codegen/flamo_to_json.py
+++ b/src/flamo_rt/codegen/flamo_to_json.py
@@ -396,13 +396,17 @@ def _traverse(model: Any, name: str, fs: float) -> dict[str, Any]:
         else:
             node["children"] = []
 
-        #capture nfft from the io layers for round-tripping
+        #capture nfft for round-tripping. flamo's Shell name-mangles its
+        #io layers (no public input_layer attr), but exposes nfft directly;
+        #fall back to the input-layer getter for other flamo versions.
         flamo_meta: dict[str, Any] = {}
-        input_layer = getattr(model, "input_layer", None)
-        if input_layer is not None:
-            nfft = getattr(input_layer, "nfft", None)
-            if nfft is not None:
-                flamo_meta["nfft"] = int(nfft)
+        nfft = getattr(model, "nfft", None)
+        if nfft is None:
+            get_in = getattr(model, "get_inputLayer", None)
+            if callable(get_in):
+                nfft = getattr(get_in(), "nfft", None)
+        if nfft is not None:
+            flamo_meta["nfft"] = int(nfft)
         if flamo_meta:
             node["flamo"] = flamo_meta
 

--- a/src/flamo_rt/codegen/json_to_flamo.py
+++ b/src/flamo_rt/codegen/json_to_flamo.py
@@ -95,8 +95,11 @@ def _build_leaf(
     if module_type == "HouseholderMatrix":
         return _build_householder(node, params, meta, m_nfft, m_adb, m_rg, device)
 
-    if module_type in ("Gain", "Matrix"):
+    if module_type == "Gain":
         return _build_gain(node, params, meta, m_nfft, m_adb, m_rg, device)
+
+    if module_type == "Matrix":
+        return _build_matrix(node, params, meta, m_nfft, m_adb, m_rg, device)
 
     if module_type == "parallelGain":
         return _build_parallel_gain(node, params, meta, m_nfft, m_adb, m_rg, device)
@@ -155,40 +158,48 @@ def _build_delay(node, params, meta, fs, nfft, adb, rg, device):
 
 
 def _build_gain(node, params, meta, nfft, adb, rg, device):
-    """construct a Gain or Matrix module (matrix or diagonal).
+    """construct a Gain module from its raw 2d parameter."""
+    values = np.array(params["gain"], dtype=np.float64)
+    size = tuple(meta.get("size", values.shape))
 
-    if the flamo metadata contains matrix_type, reconstruct a Matrix
-    with the correct type so the map function matches the original.
-    otherwise fall back to a plain Gain.
+    mod = dsp.Gain(
+        size=size, nfft=nfft,
+        alias_decay_db=adb, device=device,
+    )
+    mod.assign_value(torch.as_tensor(values, dtype=torch.float32))
+    mod.param.requires_grad_(rg)
+    return mod
+
+
+def _build_matrix(node, params, meta, nfft, adb, rg, device):
+    """construct a Matrix module from its raw parameter.
+
+    Matrix applies a type-dependent map() during forward. by
+    reconstructing with the original matrix_type and assigning the
+    raw param, flamo's matrix_gallery() reapplies the same map
+    (identity for "random", matrix_exp(skew_matrix(x)) for
+    "orthogonal"), reproducing the original effective matrix exactly.
+    the param is stored under "matrix" (random) or "skew" (orthogonal).
     """
-    if "matrix" in params:
-        values = np.array(params["matrix"], dtype=np.float64)
-        n_out, n_in = values.shape
-        size = tuple(meta.get("size", (n_out, n_in)))
-    elif "gains" in params:
-        gains = np.array(params["gains"], dtype=np.float64)
-        #diagonal gain stored as 1d, but Gain expects 2d size
-        n = len(gains)
-        size = tuple(meta.get("size", (n, 1)))
-        values = gains.reshape(size)
-    else:
-        #no params, identity passthrough
-        n_ch = node.get("input_channels", 1)
-        size = tuple(meta.get("size", (n_ch, n_ch)))
-        values = np.eye(*size, dtype=np.float64)
+    matrix_type = meta.get("matrix_type", "random")
+    n_iter = meta.get("iter", 1)
 
-    matrix_type = meta.get("matrix_type")
-    if matrix_type is not None:
-        m_iter = meta.get("iter", 1)
-        mod = dsp.Matrix(
-            size=size, nfft=nfft, matrix_type=matrix_type, iter=m_iter,
-            alias_decay_db=adb, device=device,
-        )
+    #select the stored param by matrix_type. add new types here as
+    #they are supported on the flamo_to_json side.
+    if matrix_type == "orthogonal":
+        raw = params["skew"]
+    elif matrix_type == "random":
+        raw = params["matrix"]
     else:
-        mod = dsp.Gain(
-            size=size, nfft=nfft,
-            alias_decay_db=adb, device=device,
-        )
+        raise ValueError(f"unsupported Matrix matrix_type: {matrix_type!r}")
+
+    values = np.array(raw, dtype=np.float64)
+    size = tuple(meta.get("size", values.shape))
+
+    mod = dsp.Matrix(
+        size=size, nfft=nfft, matrix_type=matrix_type, iter=n_iter,
+        alias_decay_db=adb, device=device,
+    )
     mod.assign_value(torch.as_tensor(values, dtype=torch.float32))
     mod.param.requires_grad_(rg)
     return mod
@@ -218,16 +229,15 @@ def _build_householder(node, params, meta, nfft, adb, rg, device):
 
 
 def _build_parallel_gain(node, params, meta, nfft, adb, rg, device):
-    """construct a parallelGain module."""
-    gains = params.get("gains", [1.0])
-    n_ch = len(gains)
-    size = tuple(meta.get("size", (n_ch,)))
+    """construct a parallelGain module from its raw 1d parameter."""
+    values = np.array(params["gain"], dtype=np.float64)
+    size = tuple(meta.get("size", values.shape))
 
     mod = dsp.parallelGain(
         size=size, nfft=nfft,
         alias_decay_db=adb, device=device,
     )
-    mod.assign_value(torch.as_tensor(gains, dtype=torch.float32))
+    mod.assign_value(torch.as_tensor(values, dtype=torch.float32))
     mod.param.requires_grad_(rg)
     return mod
 

--- a/src/flamo_rt/codegen/json_to_flamo.py
+++ b/src/flamo_rt/codegen/json_to_flamo.py
@@ -383,10 +383,15 @@ def _build_shell(node, fs, nfft, adb, device):
         core = dsp.Gain(size=(1, 1), nfft=shell_nfft, device=device)
         core.assign_value(torch.ones(1, 1, dtype=torch.float32))
 
+    #the Shell asserts its io layers share the core's nfft. the Shell
+    #node itself carries no flamo metadata, so align the io layers with
+    #whatever nfft the reconstructed core actually uses.
+    core_nfft = getattr(core, "nfft", shell_nfft)
+
     return system.Shell(
         core=core,
-        input_layer=dsp.FFT(shell_nfft),
-        output_layer=dsp.iFFT(shell_nfft),
+        input_layer=dsp.FFT(core_nfft),
+        output_layer=dsp.iFFT(core_nfft),
     )
 
 

--- a/src/flamo_rt/codegen/json_to_flamo.py
+++ b/src/flamo_rt/codegen/json_to_flamo.py
@@ -261,11 +261,7 @@ def _build_sos_filter(node, params, meta, fs, nfft, adb, rg, device):
 
     n_sections = len(sos)
     n_channels = len(sos[0])
-    #parallelSOSFilter's constructor size is just (N,); it internally
-    #expands to (n_sections, 6, N). the "flamo" metadata stores that
-    #expanded internal size, so derive the constructor args from the
-    #sos coefficient shape instead of round-tripping meta["size"].
-    size = (n_channels,)
+    size = tuple(meta.get("size", (n_channels,)))
 
     #try parallelSOSFilter first, fall back to parallelBiquad
     sos_6coeff = _denormalise_sos(sos)

--- a/src/flamo_rt/codegen/json_to_flamo.py
+++ b/src/flamo_rt/codegen/json_to_flamo.py
@@ -251,14 +251,18 @@ def _build_sos_filter(node, params, meta, fs, nfft, adb, rg, device):
 
     n_sections = len(sos)
     n_channels = len(sos[0])
-    size = tuple(meta.get("size", (n_channels,)))
+    #parallelSOSFilter's constructor size is just (N,); it internally
+    #expands to (n_sections, 6, N). the "flamo" metadata stores that
+    #expanded internal size, so derive the constructor args from the
+    #sos coefficient shape instead of round-tripping meta["size"].
+    size = (n_channels,)
 
     #try parallelSOSFilter first, fall back to parallelBiquad
     sos_6coeff = _denormalise_sos(sos)
 
     try:
         mod = dsp.parallelSOSFilter(
-            size=(n_sections, n_channels), nfft=nfft,
+            size=size, n_sections=n_sections, nfft=nfft,
             alias_decay_db=adb, device=device,
         )
     except AttributeError:


### PR DESCRIPTION
Hi! Several fixes for roundtrip conversion btw flamo and json. Some design choices are made but might conflict with the to_faust part. Let me know what you think.

**Key changes:**
- Gain, parallelGain and Matrix are fully separately treated, with naming respective param key "gain" and "delay".
- Matrix also have another param key "skew" because the extracted matrix is skew-symmetric only, cannot be used for rendering, would be confusing to keep it as "matrix". (Similar goes for Householder and Hadamard actually. To be updated.)
- minor API call error for flamo: nfft extraction and sosfilter construction.